### PR TITLE
Put the compilation of numba outside benchmark

### DIFF
--- a/Benchmarks/LifeModelingProblem/python/python.py
+++ b/Benchmarks/LifeModelingProblem/python/python.py
@@ -79,6 +79,7 @@ def npv_numba(q, w, P, S, r):
         v_t = v_t * v
     return result
 
+npv_numba(q, w, P, S, r)
 '''
 bm_res_numba = timeit.timeit(stmt='''npv_numba(q, w, P, S, r)''', setup=setup_numba, number=1000000)
 print(f"Numpy Vectorized: {bm_res_numba:0.3f}")


### PR DESCRIPTION
Hello,

Since Rust & Julia compilation is not in the benchmark, I think the jit compilation of numba should not be in the benchmark.

In order to do so, we can call the function one time in the setup string. 

Numba code is now 30% faster, but still way behind Julia.

Thanks a lot,
Jean